### PR TITLE
[iOS] Allow iPad popover positioning on showImagePicker method

### DIFF
--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -71,6 +71,7 @@ The `callback` will be called with a response object, refer to [The Response Obj
 | permissionDenied.text           | -   | OK      | Message of explaining permissions dialog. By default `To be able to take pictures with your camera and choose images from your library.`.                                                                                                                            |
 | permissionDenied.reTryTitle     | -   | OK      | Title of re-try button. By default `re-try`                                                                                                                                                                                                                          |
 | permissionDenied.okTitle        | -   | OK      | Title of ok button. By default `I'm sure`                                                                                                                                                                                                                            |
+| ipadPopoverPosition             | OK  | -       | Position popover for iPad when using `showImagePicker` function in 'top' (top-center of screen), 'middle' (middle-center of screen), or 'bottom' (bottom-center of screen) position. By default, it is `bottom`. (for backwards compatibility)                                                                                                                                                                                                                            |
 
 ## The Response Object
 

--- a/example/App.js
+++ b/example/App.js
@@ -86,7 +86,11 @@ export default class App extends React.Component {
       <View style={styles.container}>
         <TouchableOpacity onPress={this.selectPhotoTapped.bind(this)}>
           <View
-            style={[styles.avatar, styles.avatarContainer, {marginBottom: 20}]}>
+            style={[
+              styles.avatar,
+              styles.avatarContainer,
+              styles.avatarContainerMargin,
+            ]}>
             {this.state.avatarSource === null ? (
               <Text>Select a Photo</Text>
             ) : (
@@ -102,9 +106,7 @@ export default class App extends React.Component {
         </TouchableOpacity>
 
         {this.state.videoSource && (
-          <Text style={{margin: 8, textAlign: 'center'}}>
-            {this.state.videoSource}
-          </Text>
+          <Text style={styles.videoSource}>{this.state.videoSource}</Text>
         )}
       </View>
     );
@@ -118,15 +120,22 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: '#F5FCFF',
   },
+  avatar: {
+    borderRadius: 75,
+    width: 150,
+    height: 150,
+  },
   avatarContainer: {
     borderColor: '#9B9B9B',
     borderWidth: 1 / PixelRatio.get(),
     justifyContent: 'center',
     alignItems: 'center',
   },
-  avatar: {
-    borderRadius: 75,
-    width: 150,
-    height: 150,
+  avatarContainerMargin: {
+    marginBottom: 20,
+  },
+  videoSource: {
+    margin: 8,
+    textAlign: 'center',
   },
 });

--- a/ios/ImagePickerManager.m
+++ b/ios/ImagePickerManager.m
@@ -89,10 +89,16 @@ RCT_EXPORT_METHOD(showImagePicker:(NSDictionary *)options callback:(RCTResponseS
         UIViewController *root = RCTPresentedViewController();
 
         /* On iPad, UIAlertController presents a popover view rather than an action sheet like on iPhone. We must provide the location
-        of the location to show the popover in this case. For simplicity, we'll just display it on the bottom center of the screen
-        to mimic an action sheet */
+        of the location to show the popover in this case. We'll just display it on the top/middle/bottom center of the screen based on user preference
+        to mimic an action sheet. Default position will be bottom (as before adding option to change Y asix position) */
+        CGFloat ipadPopoverHeight = root.view.bounds.size.height;
+        if ([[self.options objectForKey:@"ipadPopoverPosition"] isEqualToString:@"top"]) {
+            ipadPopoverHeight = 0;
+        } else if ([[self.options objectForKey:@"ipadPopoverPosition"] isEqualToString:@"middle"]) {
+            ipadPopoverHeight = root.view.bounds.size.height / 2.0;
+        } 
         alertController.popoverPresentationController.sourceView = root.view;
-        alertController.popoverPresentationController.sourceRect = CGRectMake(root.view.bounds.size.width / 2.0, root.view.bounds.size.height, 1.0, 1.0);
+        alertController.popoverPresentationController.sourceRect = CGRectMake(root.view.bounds.size.width / 2.0, ipadPopoverHeight, 1.0, 1.0);
 
         if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
             alertController.popoverPresentationController.permittedArrowDirections = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ const DEFAULT_OPTIONS: ImagePickerOptions = {
     okTitle: "I'm sure",
   },
   tintColor: '',
+  ipadPopoverPosition: 'bottom',
 };
 
 type Callback = (response: ImagePickerResponse) => void;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -52,6 +52,7 @@ export interface ImagePickerOptions {
   storageOptions?: ImagePickerStorageOptions;
   permissionDenied?: ImagePickerPermissionDeniedOptions;
   tintColor?: number | string;
+  ipadPopoverPosition?: 'top' | 'middle' | 'bottom';
 }
 
 export interface ImagePickerStorageOptions {


### PR DESCRIPTION
Thanks for submitting a PR! Please read these instructions carefully:

- [x] Explain the **motivation** for making this change.
- [x] Provide a **test plan** demonstrating that the code is solid.
- [x] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch, NOT a "stable" branch.

## Motivation (required)

**Note:** I know that v2.x.x is no longer maintained, but I am not yet ready to update to v3.x.x as I use the removed `showImagePicker` API method and, looking at the issues in GitHub, v3 is not yet stable for production. I would be grateful if a 2.3.5 version could be released with this small change.

I would like that the iPad popover would be shown in a different location (e.g.: middle-center or top-center of the screen) than the default one (bottom-center of the screen), as stated in this comment: https://github.com/react-native-image-picker/react-native-image-picker/blob/397e18e6e4f07c7390955d21791b763d41247510/ios/ImagePickerManager.m#L91-L95

This is because the popover is small comparatively to the screen and hardly noticeable on an iPad in portrait when the image picker is shown as a result of a tap from a top button (see image below):

![image-picker-ipad-default-bottom-center](https://user-images.githubusercontent.com/7274664/106379219-09d23900-63b3-11eb-9014-2c6e5f147427.png)

Since different people might have different requirements for the position on the Y axis (top/middle/bottom) on iPad, I have added a new option for this and used it for the `showImagePicker` API method.
```typescript
export interface ImagePickerOptions {
  ...
  ipadPopoverPosition?: 'top' | 'middle' | 'bottom';
}
```

## Test Plan (required)

**Note:** All screenshots have been taken using an iPad Pro (9.7-inch) simulator.

**0. Default (no value for  `ipadPopoverPosition` option)**
I have tested the modified code with no provided value for the `ipadPopoverPosition` option, case in which the default value is 'bottom', displaying the popover in bottom-center position (as before adding the option, in order to provide backwards-compatibility).

_Code used for testing_
```typescript
import RNImagePicker, { ImagePickerOptions } from 'react-native-image-picker';

const options: ImagePickerOptions = {
  title: 'Select image',
  cancelButtonTitle: 'Cancel',
  takePhotoButtonTitle: 'Take photo',
  chooseFromLibraryButtonTitle: 'Choose from gallery',
  storageOptions: {
	skipBackup: true,
	path: 'images',
  },
  mediaType: 'photo',
  cameraType: 'back',
};
RNImagePicker.showImagePicker(options, handleImagePickerResponse);
```

_Result in below image_

![image](https://user-images.githubusercontent.com/7274664/106380066-8fa4b300-63b8-11eb-81e4-6cd3dea9ae4d.png)


**1. `ipadPopoverPosition` option set to 'top'**
I have tested the modified code with the 'top' value for the `ipadPopoverPosition` option, case in which the position is changed to top-center.

_Code used for testing_
```typescript
import RNImagePicker, { ImagePickerOptions } from 'react-native-image-picker';

const options: ImagePickerOptions = {
  title: 'Select image',
  cancelButtonTitle: 'Cancel',
  takePhotoButtonTitle: 'Take photo',
  chooseFromLibraryButtonTitle: 'Choose from gallery',
  storageOptions: {
	skipBackup: true,
	path: 'images',
  },
  mediaType: 'photo',
  cameraType: 'back',
  ipadPopoverPosition: 'top',
};
RNImagePicker.showImagePicker(options, handleImagePickerResponse);
```

_Result in below image_

![image](https://user-images.githubusercontent.com/7274664/106380078-a3501980-63b8-11eb-9e90-40061672eae5.png)


**2. `ipadPopoverPosition` option set to 'middle'**
I have tested the modified code with the 'middle' value for the `ipadPopoverPosition` option, case in which the position is changed to middle-center.

_Code used for testing_
```typescript
import RNImagePicker, { ImagePickerOptions } from 'react-native-image-picker';

const options: ImagePickerOptions = {
  title: 'Select image',
  cancelButtonTitle: 'Cancel',
  takePhotoButtonTitle: 'Take photo',
  chooseFromLibraryButtonTitle: 'Choose from gallery',
  storageOptions: {
	skipBackup: true,
	path: 'images',
  },
  mediaType: 'photo',
  cameraType: 'back',
  ipadPopoverPosition: 'middle',
};
RNImagePicker.showImagePicker(options, handleImagePickerResponse);
```

_Result in below image_

![image](https://user-images.githubusercontent.com/7274664/106380087-aba85480-63b8-11eb-8896-9bb35985c018.png)


**3. `ipadPopoverPosition` option set to 'bottom'**
I have tested the modified code with the 'bottom' value for the `ipadPopoverPosition` option, case in which the position is bottom-center (just like the default option, when no option is specified).

_Code used for testing_
```typescript
import RNImagePicker, { ImagePickerOptions } from 'react-native-image-picker';

const options: ImagePickerOptions = {
  title: 'Select image',
  cancelButtonTitle: 'Cancel',
  takePhotoButtonTitle: 'Take photo',
  chooseFromLibraryButtonTitle: 'Choose from gallery',
  storageOptions: {
	skipBackup: true,
	path: 'images',
  },
  mediaType: 'photo',
  cameraType: 'back',
  ipadPopoverPosition: 'bottom',
};
RNImagePicker.showImagePicker(options, handleImagePickerResponse);
```

_Result in below image_

![image](https://user-images.githubusercontent.com/7274664/106380090-b1059f00-63b8-11eb-99fc-6f132549214a.png)
